### PR TITLE
:boom: SNS topic policy moved to create_sns_topic function - a generated policy that enforces encrypted access in transit is mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,14 @@ from cdk_nag import AwsSolutionsChecks, NIST80053R5Checks, PCIDSS321Checks, HIPA
 
 
 class TestSNSStack(Stack):
-    """Test generated sns topic against AWS solutions  checks."""
+    """Test generated AWS SNS topic against AWS solutions checks."""
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
         shared_kms_key = kms.Key(self, "SharedKmsKey", enable_key_rotation=True)
 
         sns_construct = SNSTopic(self, id="topic")
-        sns_topic = sns_construct.create_sns_topic(topic_name="topic", master_key=shared_kms_key)
-        sns_construct.create_sns_topic_policy(sns_topic)
+        sns_construct.create_sns_topic(topic_name="topic", master_key=shared_kms_key)
 
         # Validate stack against AWS Solutions checklist
         Aspects.of(self).add(AwsSolutionsChecks(log_ignores=True))
@@ -237,7 +236,7 @@ from aws_cdk import Aspects
 from cdk_nag import AwsSolutionsChecks
 
 class TestALBStack(Stack):
-    """Test generated sns topic against AWS solutions  checks."""
+    """Test generated EC2 ALB against AWS recommendations."""
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)

--- a/cdk_opinionated_constructs/sns.py
+++ b/cdk_opinionated_constructs/sns.py
@@ -25,26 +25,23 @@ class SNSTopic(Construct):
         super().__init__(scope, id)
 
     def create_sns_topic(self, topic_name: str, master_key: Union[kms.IKey, None]) -> sns.Topic:
-        """Create SNS topic.
+        """Create SNS topic with resource policy that enforce encrypted access.
 
         :param topic_name: The name of SNS topic
         :param master_key: The KMS key to encrypt messages going through sns topic
         :return: The CDK object for SNS topic
         """
-        return sns.Topic(self, id=topic_name, topic_name=topic_name, master_key=master_key)
-
-    @staticmethod
-    def create_sns_topic_policy(sns_topic: sns.ITopic):
-        """Create topic policy that denies unencrypted access."""
-        sns_topic.add_to_resource_policy(
+        topic = sns.Topic(self, id=topic_name, topic_name=topic_name, master_key=master_key)
+        topic.add_to_resource_policy(
             iam.PolicyStatement(
                 sid="AllowPublishThroughSSLOnly",
                 actions=["sns:Publish"],
                 effect=iam.Effect.DENY,
-                resources=[sns_topic.topic_arn],
+                resources=[topic.topic_arn],
                 conditions={
                     "Bool": {"aws:SecureTransport": "false"},
                 },
                 principals=[iam.AnyPrincipal()],
             )
         )
+        return topic

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cdk-opinionated-constructs",
-    version="1.8.0",
+    version="1.9.0",
     description="AWS CDK constructs come without added security configurations.",
     long_description="Very rarely this is validated during the CI pipeline via tools like CDK-NAG. The idea behind this project is to create secured constructs from the start.",
     license="MIT",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
 aws-cdk-lib==2.51.1
-cdk-nag==2.21.7
-cdk-opinionated-constructs==1.8.0
-constructs==10.1.165
+cdk-nag==2.21.9
+cdk-opinionated-constructs==1.9.0
+constructs==10.1.167

--- a/test/stacks/alb_stack.py
+++ b/test/stacks/alb_stack.py
@@ -13,7 +13,7 @@ from cdk_nag import AwsSolutionsChecks
 
 
 class TestALBStack(Stack):
-    """Test generated sns topic against AWS solutions  checks."""
+    """Test generated EC2 ALB against AWS recommendations."""
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)

--- a/test/stacks/sns_stack.py
+++ b/test/stacks/sns_stack.py
@@ -10,15 +10,14 @@ from cdk_nag import AwsSolutionsChecks, NIST80053R5Checks, PCIDSS321Checks, HIPA
 
 
 class TestSNSStack(Stack):
-    """Test generated sns topic against AWS solutions  checks."""
+    """Test generated AWS SNS topic against AWS solutions checks."""
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
         shared_kms_key = kms.Key(self, "SharedKmsKey", enable_key_rotation=True)
 
         sns_construct = SNSTopic(self, id="topic")
-        sns_topic = sns_construct.create_sns_topic(topic_name="topic", master_key=shared_kms_key)
-        sns_construct.create_sns_topic_policy(sns_topic)
+        sns_construct.create_sns_topic(topic_name="topic", master_key=shared_kms_key)
 
         # Validate stack against AWS Solutions checklist
         Aspects.of(self).add(AwsSolutionsChecks(log_ignores=True))


### PR DESCRIPTION
:boom: SNS topic policy moved to create_sns_topic function - a generated policy that enforces encrypted access in transit is mandatory
:bookmark: Releasing / Version tags.
:arrow_up: Upgrading dependencies.
:bulb: Documenting source code.