### PR TITLE
:wrench: governance_stack.py is using shared method load_properties to load all configuration data

### DIFF
--- a/cdk_opinionated_constructs/stacks/notifications_stack.py
+++ b/cdk_opinionated_constructs/stacks/notifications_stack.py
@@ -76,6 +76,17 @@ class NotificationsStack(cdk.Stack):
             ),
         )
 
+        # grant aws budgets permissions to publish to the topic
+        sns_topic.add_to_resource_policy(
+            statement=iam.PolicyStatement(
+                sid="AWSBudgetsPolicy",
+                actions=["sns:Publish"],
+                resources=[sns_topic.topic_arn],
+                principals=[iam.ServicePrincipal(service="budgets.amazonaws.com")],
+                effect=iam.Effect.ALLOW,
+            ),
+        )
+
         ssm.StringParameter(
             self,
             id="sns_topic_ssm_param",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.6.6",
+    version="3.6.7",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
 aws-cdk-lib==2.126.0
 cdk-monitoring-constructs==7.6.0
 cdk-nag==2.28.27
-cdk-opinionated-constructs==3.6.0
+cdk-opinionated-constructs==3.6.7
 constructs==10.3.0


### PR DESCRIPTION


:wrench: notifications_stack.py, extending resource permissions to allow aws budgets publishing messages :arrow_up:
:bookmark: 3.6.7