### PR TITLE
3.6.9

### DIFF
--- a/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
@@ -119,7 +119,7 @@ def main():
     cloudwatch = create_cloudwatch_client(aws_region)
 
     end_time = datetime.now(UTC)
-    start_time = end_time - timedelta(minutes=25)
+    start_time = end_time - timedelta(minutes=10)
 
     datapoints = get_metric_statistics(
         client=cloudwatch,

--- a/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
@@ -111,7 +111,7 @@ def main():
     cloudwatch = create_cloudwatch_client(aws_region)
 
     end_time = datetime.now(UTC)
-    start_time = end_time - timedelta(minutes=25)
+    start_time = end_time - timedelta(minutes=10)
 
     datapoints = get_metric_statistics(cloudwatch, "AWS/Lambda", "Errors", function_name, start_time, end_time)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.6.8",
+    version="3.6.9",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
 aws-cdk-lib==2.130.0
 cdk-monitoring-constructs==7.7.0
-cdk-nag==2.28.46
-cdk-opinionated-constructs==3.6.8
+cdk-nag==2.28.47
+cdk-opinionated-constructs==3.6.9
 constructs==10.3.0


### PR DESCRIPTION
:wrench: Decreasing start time to last 10 minutes from previously defined 25 in get_lambda_successful_invocations.py and get_lambda_unsuccessful_invocations.py