### PR TITLE
3.7.0 Add support for multiple alarm email subscriptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -31,7 +31,7 @@ repos:
       - id: ssort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.3.3'
+    rev: 'v0.3.5'
     hooks:
       - id: ruff
         args: [ --fix]
@@ -71,7 +71,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/returntocorp/semgrep # semgrep does not support linux arm64
-    rev: 'v1.66.0'
+    rev: 'v1.67.0'
     hooks:
       - id: semgrep
         # See semgrep.dev/rulesets to select a ruleset and copy its URL

--- a/cdk_opinionated_constructs/stacks/notifications_stack.py
+++ b/cdk_opinionated_constructs/stacks/notifications_stack.py
@@ -86,9 +86,16 @@ class NotificationsStack(cdk.Stack):
             parameter_name=f"/{config_vars.project}/{config_vars.stage}/topic/alarm/arn",
         )
 
-        sns_topic.add_subscription(
-            topic_subscription=sns_subscriptions.EmailSubscription(email_address=props["ci_cd_notification_email"]),
-        )
+        if ci_cd_notification_email := props.get("ci_cd_notification_email"):
+            sns_topic.add_subscription(
+                topic_subscription=sns_subscriptions.EmailSubscription(email_address=ci_cd_notification_email),
+            )
+
+        if alarm_emails := props.get("alarm_emails"):
+            for email in alarm_emails:
+                sns_topic.add_subscription(
+                    topic_subscription=sns_subscriptions.EmailSubscription(email_address=email),
+                )
 
         if notifications_vars.slack_workspace_id and notifications_vars.slack_channel_id_alarms:
             chatbot_iam_role = iam.Role(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.6.14",
+    version="3.7.0",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION
feat(notifications): add support for multiple alarm email subscriptions

Update NotificationsStack to conditionally add an email subscription for the ci_cd_notification_email prop
Add support for an optional alarm_emails prop to specify multiple email addresses
If alarm_emails prop is provided, add an email subscription for each email address to the SNS topic
This allows greater flexibility in configuring email notifications for alarms by supporting a list of email addresses in addition to the existing single ci_cd_notification_email property.