### PR TITLE
feat(pipeline-notifications): enhance pipeline notifications configur…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.7.0",
+    version="3.7.1",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION
…ation

Refactor create_pipeline_notifications() function signature: Add use_chatbot boolean parameter to enable/disable Slack notifications via Chatbot Improve parameter descriptions
Update function docstring to clarify functionality and configuration options Conditionally enable Slack notifications using Chatbot based on provided config values The changes enhance the pipeline notifications setup by adding a flag to control Slack notifications via AWS Chatbot. The function signature and docstring are updated to improve clarity around the configuration options and behavior. Slack notifications using Chatbot are now enabled conditionally based on the provided Slack workspace ID, channel ID, and use_chatbot flag.