### PR TITLE
feat(pipeline): add new CodePipeline execution event notifications

### DIFF
--- a/cdk_opinionated_constructs/stacks/__init__.py
+++ b/cdk_opinionated_constructs/stacks/__init__.py
@@ -136,6 +136,11 @@ def pipeline_notifications(self, sns_topic: sns.ITopic) -> None:
         detail_type=DetailType.FULL,
         events=[
             "codepipeline-pipeline-pipeline-execution-failed",
+            "codepipeline-pipeline-pipeline-execution-canceled",
+            "codepipeline-pipeline-pipeline-execution-started",
+            "codepipeline-pipeline-pipeline-execution-resumed",
+            "codepipeline-pipeline-pipeline-execution-succeeded",
+            "codepipeline-pipeline-pipeline-execution-superseded",
             "codepipeline-pipeline-action-execution-failed",
             "codepipeline-pipeline-stage-execution-failed",
             "codepipeline-pipeline-manual-approval-failed",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.7.1",
+    version="3.7.2",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION
Update pipeline_notifications method in stacks/init.py to include additional CodePipeline execution events for sending notifications: codepipeline-pipeline-pipeline-execution-canceled
codepipeline-pipeline-pipeline-execution-started
codepipeline-pipeline-pipeline-execution-resumed
codepipeline-pipeline-pipeline-execution-succeeded codepipeline-pipeline-pipeline-execution-superseded Bump version in setup.py from 3.7.1 to 3.7.2
This commit enhances the pipeline notifications to cover more execution events, providing better visibility into the pipeline status. The added events will trigger notifications for pipeline execution cancellation, start, resume, success, and superseding.