### PR TITLE
3.7.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,18 +26,18 @@ repos:
       - id: detect-aws-credentials
         args: [ --allow-missing-credentials ]
   - repo: https://github.com/bwhmather/ssort
-    rev: 0.12.4
+    rev: 0.13.0
     hooks:
       - id: ssort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.3.5'
+    rev: 'v0.5.0'
     hooks:
       - id: ruff
         args: [ --fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0"
+    rev: "v1.10.1"
     hooks:
       - id: mypy
         args: [--explicit-package-bases, --namespace-packages, --ignore-missing-imports]
@@ -67,11 +67,11 @@ repos:
       - id: xenon
         args: ["--max-average=A", "--max-modules=A", "--max-absolute=B", "-e 'tests/*,.venv/*,cdk.out/*'"]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.2
+    rev: v8.18.4
     hooks:
       - id: gitleaks
   - repo: https://github.com/returntocorp/semgrep # semgrep does not support linux arm64
-    rev: 'v1.67.0'
+    rev: 'v1.73.0'
     hooks:
       - id: semgrep
         # See semgrep.dev/rulesets to select a ruleset and copy its URL

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,12 @@ activate:
 
 install:
 	@echo "Installing dependencies from requirements files"
+	pip install uv pur
 	pip install --upgrade pip
-	pip install -r requirements.txt
-	pip install -r requirements-dev.txt
-	pip install pre-commit pytest
+	pip install --upgrade pip
+	uv pip install -r test/requirements.txt
+	uv pip install -r test/requirements-dev.txt
+	uv pip install pre-commit pytest pytest-snapshot
 
 pre-commit:
 	@echo "Running pre-commit"
@@ -44,6 +46,8 @@ test:
 
 update:
 	@echo "Updating used tools and scripts"
+	pur -r test/requirements.txt
+	pur -r test/requirements-dev.txt
 	pre-commit autoupdate
 
 clean:

--- a/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
@@ -1,3 +1,4 @@
+import operator
 import sys
 
 from datetime import UTC, datetime, timedelta
@@ -78,7 +79,7 @@ def print_metric_data(datapoints):
         print("No datapoints found")
         sys.exit(1)
 
-    datapoints.sort(key=lambda x: x["Timestamp"])
+    datapoints.sort(key=operator.itemgetter("Timestamp"))
 
     for datapoint in datapoints:
         timestamp = datapoint["Timestamp"]

--- a/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
@@ -1,3 +1,4 @@
+import operator
 import sys
 
 from datetime import UTC, datetime, timedelta
@@ -70,7 +71,7 @@ def print_metric_data(datapoints):
         print("No datapoints found")
         sys.exit(1)
 
-    datapoints.sort(key=lambda x: x["Timestamp"])
+    datapoints.sort(key=operator.itemgetter("Timestamp"))
 
     for datapoint in datapoints:
         timestamp = datapoint["Timestamp"]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.7.3",
+    version="3.7.4",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib==2.147.2
-cdk-monitoring-constructs==7.13.0
-cdk-nag==2.28.154
+aws-cdk-lib==2.147.3
+cdk-monitoring-constructs==8.0.0
+cdk-nag==2.28.156
 cdk-opinionated-constructs==3.7.3
 constructs==10.3.0


### PR DESCRIPTION

perf(tests): optimize lambda invocation metric sorting

- Replace lambda function with operator.itemgetter() for sorting datapoints
- Implement this change in both successful and unsuccessful invocation scripts
- Add import for operator module in both files

This change improves performance when sorting metric datapoints by timestamp.


chore(deps): update pre-commit hooks and project dependencies

- Update pre-commit hook versions:
  - ssort: 0.12.4 -> 0.13.0
  - ruff: v0.3.5 -> v0.5.0
  - mypy: v1.9.0 -> v1.10.1
  - gitleaks: v8.18.2 -> v8.18.4
  - semgrep: v1.67.0 -> v1.73.0

- Update project dependencies:
  - aws-cdk-lib: 2.147.2 -> 2.147.3
  - cdk-monitoring-constructs: 7.13.0 -> 8.0.0
  - cdk-nag: 2.28.154 -> 2.28.156

- Modify Makefile:
  - Add uv and pur installation
  - Update dependency installation process using uv
  - Add pytest-snapshot to installed packages
  - Include pur commands for updating requirements


chore(version): bump package version to 3.7.4

Increment the version number in setup.py from 3.7.3 to 3.7.4.
This minor version update likely includes small improvements or bug fixes.