### PR TITLE
feat(lambda-metrics): add configurable time range for metric retrieval

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,13 +31,13 @@ repos:
       - id: ssort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.5.0'
+    rev: 'v0.5.5'
     hooks:
       - id: ruff
         args: [ --fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.1"
+    rev: "v1.11.0"
     hooks:
       - id: mypy
         args: [--explicit-package-bases, --namespace-packages, --ignore-missing-imports]

--- a/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
@@ -94,7 +94,7 @@ def print_metric_data(datapoints):
             sys.exit(1)
 
 
-def main():
+def main(time_delta_minutes=10):
     """The main function to fetch and print Lambda invocation metric data.
 
     It requires two command line arguments - the function name and AWS region.
@@ -110,17 +110,20 @@ def main():
     - None
     """
 
-    if len(sys.argv) != 3:
-        print("Usage: python script.py <function_name> <aws_region>")
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print("Usage: python script.py <function_name> <aws_region> [time_delta_minutes]")
         sys.exit(1)
 
     function_name = sys.argv[1]
     aws_region = sys.argv[2]
 
+    if len(sys.argv) == 4:
+        time_delta_minutes = int(sys.argv[3])
+
     cloudwatch = create_cloudwatch_client(aws_region)
 
     end_time = datetime.now(UTC)
-    start_time = end_time - timedelta(minutes=10)
+    start_time = end_time - timedelta(minutes=time_delta_minutes)
 
     datapoints = get_metric_statistics(
         client=cloudwatch,

--- a/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
@@ -86,7 +86,7 @@ def print_metric_data(datapoints):
             sys.exit(0)
 
 
-def main():
+def main(time_delta_minutes=10):
     """The main function to fetch and print Lambda error metric data.
 
     It requires two command line arguments - the function name and AWS region.
@@ -102,17 +102,20 @@ def main():
     - None
     """
 
-    if len(sys.argv) != 3:
-        print("Usage: python script.py <function_name> <aws_region>")
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print("Usage: python script.py <function_name> <aws_region> [time_delta_minutes]")
         sys.exit(1)
 
     function_name = sys.argv[1]
     aws_region = sys.argv[2]
 
+    if len(sys.argv) == 4:
+        time_delta_minutes = int(sys.argv[3])
+
     cloudwatch = create_cloudwatch_client(aws_region)
 
     end_time = datetime.now(UTC)
-    start_time = end_time - timedelta(minutes=10)
+    start_time = end_time - timedelta(minutes=time_delta_minutes)
 
     datapoints = get_metric_statistics(cloudwatch, "AWS/Lambda", "Errors", function_name, start_time, end_time)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.8.0",
+    version="3.8.1",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION


- Modify main functions in get_lambda_successful_invocations.py and 
  get_lambda_unsuccessful_invocations.py to accept an optional time_delta_minutes parameter
- Update command-line argument parsing to allow for an optional third argument
- Change the default time range from a hard-coded 10 minutes to a configurable value
- Update usage instructions in both files to reflect the new optional parameter

This change allows users to specify a custom time range when retrieving Lambda 
invocation metrics, providing more flexibility in metric analysis.
