### PR TITLE
feat(tests): add retry logic for CloudWatch metric retrieval

### DIFF
--- a/cdk_opinionated_constructs/stacks/pipeline_trigger_stack.py
+++ b/cdk_opinionated_constructs/stacks/pipeline_trigger_stack.py
@@ -42,7 +42,7 @@ class PipelineTriggerStack(cdk.Stack):
         config_vars = ConfigurationVars(**props)
 
         # Filter all ssm parameters that have the name of the stage
-        filtered_ssm_parameters = list(
+        filtered_ssm_parameters: list[str] = list(
             filter(lambda x: config_vars.stage in x, config_vars.plugins.pipeline_trigger_ssm_parameters)  # type: ignore
         )  # type: ignore
 

--- a/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_successful_invocations.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 import boto3
 
 from botocore.config import Config
+from tenacity import retry, stop_after_delay, wait_fixed
 
 
 def create_cloudwatch_client(region_name):
@@ -94,6 +95,30 @@ def print_metric_data(datapoints):
             sys.exit(1)
 
 
+@retry(stop=stop_after_delay(300), wait=wait_fixed(10))
+def get_metric_statistics_with_retry(*args, **kwargs):
+    """
+    Parameters:
+        *args: Variable length argument list to be passed to the get_metric_statistics function.
+        **kwargs: Arbitrary keyword arguments to be passed to the get_metric_statistics function.
+
+    Functionality:
+        Calls the get_metric_statistics function with the provided arguments and retries the operation
+        if no datapoints are found. The function uses the @retry decorator to implement the retry logic.
+
+    Returns:
+        list: A list of datapoints returned by the get_metric_statistics function.
+
+    Raises:
+        ValueError: If no datapoints are found after retrying.
+    """
+
+    datapoints = get_metric_statistics(*args, **kwargs)
+    if not datapoints:
+        raise ValueError("No datapoints found")
+    return datapoints
+
+
 def main(time_delta_minutes=10):
     """The main function to fetch and print Lambda invocation metric data.
 
@@ -125,16 +150,19 @@ def main(time_delta_minutes=10):
     end_time = datetime.now(UTC)
     start_time = end_time - timedelta(minutes=time_delta_minutes)
 
-    datapoints = get_metric_statistics(
-        client=cloudwatch,
-        namespace="AWS/Lambda",
-        metric_name="Invocations",
-        function_name=function_name,
-        start_time=start_time,
-        end_time=end_time,
-    )
-
-    print_metric_data(datapoints)
+    try:
+        datapoints = get_metric_statistics_with_retry(
+            client=cloudwatch,
+            namespace="AWS/Lambda",
+            metric_name="Invocations",
+            function_name=function_name,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        print_metric_data(datapoints)
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
+++ b/cdk_opinionated_constructs/tests/integration/get_lambda_unsuccessful_invocations.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 import boto3
 
 from botocore.config import Config
+from tenacity import retry, stop_after_delay, wait_fixed
 
 
 def create_cloudwatch_client(region_name):
@@ -86,6 +87,30 @@ def print_metric_data(datapoints):
             sys.exit(0)
 
 
+@retry(stop=stop_after_delay(300), wait=wait_fixed(10))
+def get_metric_statistics_with_retry(*args, **kwargs):
+    """
+    Parameters:
+        *args: Variable length argument list to be passed to the get_metric_statistics function.
+        **kwargs: Arbitrary keyword arguments to be passed to the get_metric_statistics function.
+
+    Functionality:
+        Calls the get_metric_statistics function with the provided arguments and retries the operation
+        if no datapoints are found. The function uses the @retry decorator to implement the retry logic.
+
+    Returns:
+        list: A list of datapoints returned by the get_metric_statistics function.
+
+    Raises:
+        ValueError: If no datapoints are found after retrying.
+    """
+
+    datapoints = get_metric_statistics(*args, **kwargs)
+    if not datapoints:
+        raise ValueError("No datapoints found")
+    return datapoints
+
+
 def main(time_delta_minutes=10):
     """The main function to fetch and print Lambda error metric data.
 
@@ -117,9 +142,19 @@ def main(time_delta_minutes=10):
     end_time = datetime.now(UTC)
     start_time = end_time - timedelta(minutes=time_delta_minutes)
 
-    datapoints = get_metric_statistics(cloudwatch, "AWS/Lambda", "Errors", function_name, start_time, end_time)
-
-    print_metric_data(datapoints)
+    try:
+        datapoints = get_metric_statistics_with_retry(
+            client=cloudwatch,
+            namespace="AWS/Lambda",
+            metric_name="Invocations",
+            function_name=function_name,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        print_metric_data(datapoints)
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "pydantic>=2.5.0",
         "pydantic-core>=2.14.0",
         "pyyaml>=6.0.0",
+        "tenacity>=8.0.1",
     ],
     python_requires=">=3.11",
 )


### PR DESCRIPTION
- Implement retry mechanism using tenacity library in integration tests
- Add get_metric_statistics_with_retry function to handle retries
- Update main functions to use the new retry logic
- Add error handling for cases where no datapoints are found
- Include tenacity as a new dependency in setup.py

This change improves the reliability of integration tests by retrying CloudWatch metric retrieval operations, reducing false negatives due to eventual consistency in AWS services.