### PR TITLE
fix(pipeline): update MS Teams notification configuration

### DIFF
--- a/cdk_opinionated_constructs/stacks/__init__.py
+++ b/cdk_opinionated_constructs/stacks/__init__.py
@@ -270,7 +270,7 @@ def _configure_pipeline_ms_teams_notifications(
             scope,
             "ci-cd-ms-teams-chatbot",
             configuration_name=f"{pipeline_vars.project}-ci-cd",
-            notification_topics=[notifications_sns_topic],
+            sns_topic_arns=[notifications_sns_topic.topic_arn],
             team_id=pipeline_vars.ms_teams_team_id,
             teams_channel_id=pipeline_vars.ms_teams_ci_cd_channel_id,
             teams_tenant_id=pipeline_vars.ms_teams_tenant_id,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.9.1",
+    version="3.9.2",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION


Update the `_configure_pipeline_ms_teams_notifications` function to use
`sns_topic_arns` instead of `notification_topics` when configuring the
CI/CD MS Teams chatbot. This change likely aligns with updated API
requirements or best practices for SNS topic integration.

- Replace `notification_topics=[notifications_sns_topic]` with
  `sns_topic_arns=[notifications_sns_topic.topic_arn]`