### PR TITLE
refactor(notifications): simplify MS Teams integration and update stack initialization

### DIFF
--- a/cdk_opinionated_constructs/stacks/notifications_stack.py
+++ b/cdk_opinionated_constructs/stacks/notifications_stack.py
@@ -137,23 +137,13 @@ class NotificationsStack(cdk.Stack):
         )
 
     def _add_ms_teams_integration(
-        self,
-        config_vars: ConfigurationVars,
-        notifications_vars: NotificationVars,
-        chatbot_iam_role: iam.Role,
-        name_prefix: str | None,
+        self, config_vars: ConfigurationVars, notifications_vars: NotificationVars, chatbot_iam_role: iam.Role
     ):
         """Configures MS Teams integration for notifications."""
-
-        configuration_name = f"{config_vars.project}-{config_vars.stage}-ms-teams"
-
-        if name_prefix:
-            configuration_name = f"{config_vars.project}-{config_vars.stage}-{name_prefix}-ms-teams"
-
         chatbot.CfnMicrosoftTeamsChannelConfiguration(
             self,
             "ms_teams_chatbot",
-            configuration_name=configuration_name,
+            configuration_name=f"{config_vars.project}-{config_vars.stage}-ms-teams",
             iam_role_arn=chatbot_iam_role.role_arn,
             team_id=notifications_vars.ms_teams_team_id,
             teams_channel_id=notifications_vars.ms_teams_channel_id_alarms,
@@ -162,8 +152,8 @@ class NotificationsStack(cdk.Stack):
             sns_topic_arns=[self._sns_topic.topic_arn],
         )
 
-    def __init__(self, scope: Construct, construct_id: str, env: cdk.Environment, props: dict) -> None:
-        super().__init__(scope, construct_id, env=env)
+    def __init__(self, scope: Construct, construct_id: str, env: cdk.Environment, props: dict, **kwargs) -> None:
+        super().__init__(scope, construct_id, env=env, **kwargs)
         config_vars = ConfigurationVars(**props)
         props_env = load_properties(stage=config_vars.stage)
         notifications_vars = NotificationVars(**props_env)
@@ -177,9 +167,7 @@ class NotificationsStack(cdk.Stack):
             if notifications_vars.slack_workspace_id and notifications_vars.slack_channel_id_alarms:
                 self._add_slack_integration(config_vars, notifications_vars, chatbot_iam_role)
             if notifications_vars.ms_teams_team_id and notifications_vars.ms_teams_channel_id_alarms:
-                self._add_ms_teams_integration(
-                    config_vars, notifications_vars, chatbot_iam_role, name_prefix=props.get("ms_teams_prefix")
-                )
+                self._add_ms_teams_integration(config_vars, notifications_vars, chatbot_iam_role)
 
         # Validate stack against AWS Solutions checklist
         NagSuppressions.add_stack_suppressions(self, self.nag_suppression())

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.10.1",
+    version="3.11.1",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION

- Remove `name_prefix` parameter from `_add_ms_teams_integration` method
- Simplify configuration name for MS Teams channel
- Update stack initialization to pass through additional kwargs
- Bump package version from 3.10.1 to 3.11.1

BREAKING CHANGE: Removed support for custom MS Teams configuration name prefix