### PR TITLE
feat!: upgrade Python runtime to 3.13 and bump version to 4.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Set the desired Python interpreter (change if needed)
 PYTHON := python3.13
-VERSION := 3.13.9
+VERSION := 4.0.0
 # Virtual environment directory
 VENV := .venv
 

--- a/cdk_opinionated_constructs/lmb.py
+++ b/cdk_opinionated_constructs/lmb.py
@@ -85,7 +85,7 @@ class AWSPythonLambdaFunction(Construct):
             self,
             id=construct_id,
             code=lmb.Code.from_asset(code_path),
-            compatible_runtimes=[lmb.Runtime.PYTHON_3_11],  # type: ignore
+            compatible_runtimes=[lmb.Runtime.PYTHON_3_13],  # type: ignore
         )
 
     def create_lambda_function(
@@ -172,7 +172,7 @@ class AWSPythonLambdaFunction(Construct):
             on_failure=kwargs.get("on_failure"),
             profiling=True,
             reserved_concurrent_executions=reserved_concurrent_executions,
-            runtime=lmb.Runtime.PYTHON_3_11,  # type: ignore
+            runtime=lmb.Runtime.PYTHON_3_13,  # type: ignore
             security_groups=kwargs.get("security_groups"),
             timeout=cdk.Duration.seconds(timeout),
             tracing=lmb.Tracing.ACTIVE if tracing else lmb.Tracing.DISABLED,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="3.13.9",
+    version="4.0.0",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION
* Update Lambda function runtime from Python 3.11 to Python 3.13
* Increment package version from 3.13.9 to 4.0.0 in setup.py and Makefile

BREAKING CHANGE: Python runtime upgrade requires AWS Lambda functions to be compatible with Python 3.13