### PR TITLE
feat(pipeline): add image tag parameter support and bump version to 4.3.4

### DIFF
--- a/cdk_opinionated_constructs/libs/pipeline_v2/docker.py
+++ b/cdk_opinionated_constructs/libs/pipeline_v2/docker.py
@@ -9,6 +9,7 @@ from cdk_opinionated_constructs.stages.logic import (
     attach_role,
     default_install_commands,
     get_build_image_for_architecture,
+    revert_to_original_role_command,
     runtime_versions,
 )
 
@@ -68,6 +69,10 @@ def _create_docker_build_commands(
         f"--type String --overwrite",
         f'aws ssm put-parameter --name "{image_uri_param}" '
         f'--region {env.region} --value "$ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION" '
+        f"--type String --overwrite",
+        revert_to_original_role_command,
+        f'aws ssm put-parameter --name "{image_tag_param}" '
+        f'--region {env.region} --value "$CODEBUILD_RESOLVED_SOURCE_VERSION" '
         f"--type String --overwrite",
     ]
 

--- a/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
+++ b/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
@@ -21,7 +21,7 @@ def _create_trivy_install_commands(
     stage_name: str,
     cpu_architecture: Literal["arm64", "amd64"],
     assume_commands: list[str],
-    cdk_opinionated_constructs_version: str = "4.3.3",
+    cdk_opinionated_constructs_version: str = "4.3.4",
     trivy_version: str = "0.63.0",
 ) -> dict[str, list[str] | list[str | Any]]:
     """
@@ -32,7 +32,7 @@ def _create_trivy_install_commands(
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for installing the
             appropriate Trivy version
         cdk_opinionated_constructs_version (str): Version of cdk-opinionated-constructs
-            to use for the Trivy parser script, defaults to "4.2.5"
+            to use for the Trivy parser script, defaults to "4.3.4"
         trivy_version (str): Version of Trivy to install, defaults to "0.63.0"
 
     Functionality:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="4.3.3",
+    version="4.3.4",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
 aws-cdk-lib==2.200.1
 cdk-monitoring-constructs==8.3.6
 cdk-nag==2.36.12
-cdk-opinionated-constructs==4.3.2
+cdk-opinionated-constructs==4.3.3
 constructs==10.4.2


### PR DESCRIPTION
feat(pipeline): add image tag parameter support and bump version to 4.3.4

Enhanced CodeBuild projects to support saving image tags to SSM parameters, enabling better traceability of build artifacts with `ssm:PutParameter` actions. Updated the `revert_to_original_role_command` logic to maintain role consistency during parameter updates.

Additionally, bumped `cdk-opinionated-constructs` version to `4.3.4` across the project, ensuring consistency in version tracking.

