### PR TITLE
chore(deps): bump cdk-opinionated-constructs to 4.5.0 and project ver…

### DIFF
--- a/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
+++ b/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
@@ -21,7 +21,7 @@ def _create_trivy_install_commands(
     stage_name: str,
     cpu_architecture: Literal["arm64", "amd64"],
     assume_commands: list[str],
-    cdk_opinionated_constructs_version: str = "4.4.2",
+    cdk_opinionated_constructs_version: str = "4.5.0",
     trivy_version: str = "0.64.1",
 ) -> dict[str, list[str] | list[str | Any]]:
     """
@@ -32,7 +32,7 @@ def _create_trivy_install_commands(
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for installing the
             appropriate Trivy version
         cdk_opinionated_constructs_version (str): Version of cdk-opinionated-constructs
-            to use for the Trivy parser script, defaults to "4.4.2"
+            to use for the Trivy parser script, defaults to "4.5.0"
         trivy_version (str): Version of Trivy to install, defaults to "0.64.1"
 
     Functionality:

--- a/cdk_opinionated_constructs/stages/logic/__init__.py
+++ b/cdk_opinionated_constructs/stages/logic/__init__.py
@@ -627,7 +627,7 @@ def scan_image_with_trivy(
     cpu_architecture: Literal["arm64", "amd64"],
     pipeline_artifacts_bucket: s3.Bucket | s3.IBucket,
     trivy_version: str = "0.64.1",
-    cdk_opinionated_constructs_version: str = "4.4.2",
+    cdk_opinionated_constructs_version: str = "4.5.0",
 ) -> pipelines.CodeBuildStep:
     """
     Parameters:
@@ -637,7 +637,7 @@ def scan_image_with_trivy(
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for the build environment
         pipeline_artifacts_bucket (s3.Bucket | s3.IBucket): S3 bucket for storing build artifacts
         trivy_version (str): Version of Trivy scanner to install (defaults to "0.64.1")
-        cdk_opinionated_constructs_version (str): Version of CDK constructs package (defaults to "4.4.2")
+        cdk_opinionated_constructs_version (str): Version of CDK constructs package (defaults to "4.5.0")
 
     Functionality:
         Creates a CodeBuild step that performs security scanning of container images using Trivy:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="4.5.0",
+    version="4.5.1",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION
…sion to 4.5.1

Updated `cdk_opinionated_constructs_version` to `4.5.0` in multiple modules, reflecting the adoption of the latest version of the constructs package. Incremented the project version to `4.5.1` in `setup.py` to signify this update.

These changes ensure the project remains aligned with the latest enhancements and maintain consistency across versions.