### PR TITLE
chore(deps): update cdk-opinionated-constructs to 4.5.3 and project v…

### DIFF
--- a/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
+++ b/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
@@ -21,7 +21,7 @@ def _create_trivy_install_commands(
     stage_name: str,
     cpu_architecture: Literal["arm64", "amd64"],
     assume_commands: list[str],
-    cdk_opinionated_constructs_version: str = "4.5.1",
+    cdk_opinionated_constructs_version: str = "4.5.3",
     trivy_version: str = "0.64.1",
 ) -> dict[str, list[str] | list[str | Any]]:
     """
@@ -32,7 +32,7 @@ def _create_trivy_install_commands(
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for installing the
             appropriate Trivy version
         cdk_opinionated_constructs_version (str): Version of cdk-opinionated-constructs
-            to use for the Trivy parser script, defaults to "4.5.1"
+            to use for the Trivy parser script, defaults to "4.5.3"
         trivy_version (str): Version of Trivy to install, defaults to "0.64.1"
 
     Functionality:

--- a/cdk_opinionated_constructs/stages/logic/__init__.py
+++ b/cdk_opinionated_constructs/stages/logic/__init__.py
@@ -627,7 +627,7 @@ def scan_image_with_trivy(
     cpu_architecture: Literal["arm64", "amd64"],
     pipeline_artifacts_bucket: s3.Bucket | s3.IBucket,
     trivy_version: str = "0.64.1",
-    cdk_opinionated_constructs_version: str = "4.5.1",
+    cdk_opinionated_constructs_version: str = "4.5.3",
 ) -> pipelines.CodeBuildStep:
     """
     Parameters:
@@ -637,7 +637,7 @@ def scan_image_with_trivy(
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for the build environment
         pipeline_artifacts_bucket (s3.Bucket | s3.IBucket): S3 bucket for storing build artifacts
         trivy_version (str): Version of Trivy scanner to install (defaults to "0.64.1")
-        cdk_opinionated_constructs_version (str): Version of CDK constructs package (defaults to "4.5.1")
+        cdk_opinionated_constructs_version (str): Version of CDK constructs package (defaults to "4.5.3")
 
     Functionality:
         Creates a CodeBuild step that performs security scanning of container images using Trivy:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="4.5.3",
+    version="4.5.4",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
 aws-cdk-lib==2.206.0
 cdk-monitoring-constructs==9.12.0
 cdk-nag==2.36.42
-cdk-opinionated-constructs==4.5.1
+cdk-opinionated-constructs==4.5.3
 constructs==10.4.2


### PR DESCRIPTION
…ersion to 4.5.4

Updated `cdk_opinionated_constructs_version` to `4.5.3` across relevant modules and incremented the project version to `4.5.4` in `setup.py`. Updated `requirements.txt` to reflect the dependency change.

These updates ensure the project utilizes the latest features and improvements, maintaining consistency and alignment with the updated library version.