### PR TITLE
chore(deps): bump soci snapshotter to 0.11.1 and project version to 4.5.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,13 @@ repos:
       - id: ssort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.12.4'
+    rev: 'v0.12.7'
     hooks:
       - id: ruff
         args: [ --fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.17.0"
+    rev: "v1.17.1"
     hooks:
       - id: mypy
         args: [--explicit-package-bases, --namespace-packages, --ignore-missing-imports, --no-warn-unused-ignores]
@@ -76,7 +76,7 @@ repos:
       -   id: detect-secrets
           exclude: (cdk.context.json|cdk/tests/infrastructure/snapshots/test_s3_stack/test_snapshot/ppe.yaml)
   - repo: https://github.com/owenlamont/uv-secure
-    rev: 0.12.1
+    rev: 0.12.2
     hooks:
       - id: uv-secure
   - repo: https://github.com/hukkin/mdformat

--- a/cdk_opinionated_constructs/libs/pipeline_v2/soci_index.py
+++ b/cdk_opinionated_constructs/libs/pipeline_v2/soci_index.py
@@ -20,7 +20,7 @@ def _create_soci_index_install_commands(
     pipeline_vars: PipelineVars,
     stage_name: str,
     cpu_architecture: Literal["arm64", "amd64"],
-    soci_snapshotter_version: str = "0.9.0",
+    soci_snapshotter_version: str = "0.11.1",
 ) -> list[str]:
     """
     Parameters:
@@ -29,7 +29,7 @@ def _create_soci_index_install_commands(
         stage_name (str): Name of the stage being deployed
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for which to install
             SOCI binaries (arm64 or amd64)
-        soci_snapshotter_version (str): Version of SOCI snapshotter to install, defaults to "0.9.0"
+        soci_snapshotter_version (str): Version of SOCI snapshotter to install, defaults to "0.11.1"
 
     Functionality:
         Generates a list of shell commands that:

--- a/cdk_opinionated_constructs/stages/logic/__init__.py
+++ b/cdk_opinionated_constructs/stages/logic/__init__.py
@@ -209,7 +209,7 @@ def soci_image_builder(
     pipeline_vars: PipelineVars,
     stage_name: str,
     cpu_architecture: Literal["arm64", "amd64"],
-    soci_snapshotter_version: str = "0.9.0",
+    soci_snapshotter_version: str = "0.11.1",
 ) -> pipelines.CodeBuildStep:
     """
     Parameters:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="4.5.6",
+    version="4.5.7",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,4 @@
-aws-cdk-lib==2.206.0
-cdk-monitoring-constructs==9.12.0
-cdk-nag==2.36.42
-cdk-opinionated-constructs==4.5.3
+aws-cdk-lib==2.209.1
+cdk-nag==2.36.55
+cdk-opinionated-constructs==4.5.6
 constructs==10.4.2


### PR DESCRIPTION


Updated `soci_snapshotter_version` from `0.9.0` to `0.11.1` across relevant modules to benefit from the latest features and improvements. Incremented the project version to `4.5.7` in `setup.py` to reflect the update.

These changes ensure the project remains aligned with the updated dependency versions and maintains compatibility with the latest enhancements.