### PR TITLE
chore(deps): bump cdk-opinionated-constructs to 4.5.7 and project version to 4.5.8

### DIFF
--- a/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
+++ b/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
@@ -21,7 +21,7 @@ def _create_trivy_install_commands(
     stage_name: str,
     cpu_architecture: Literal["arm64", "amd64"],
     assume_commands: list[str],
-    cdk_opinionated_constructs_version: str = "4.5.4",
+    cdk_opinionated_constructs_version: str = "4.5.7",
     trivy_version: str = "0.65.0",
 ) -> dict[str, list[str] | list[str | Any]]:
     """
@@ -32,7 +32,7 @@ def _create_trivy_install_commands(
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for installing the
             appropriate Trivy version
         cdk_opinionated_constructs_version (str): Version of cdk-opinionated-constructs
-            to use for the Trivy parser script, defaults to "4.5.4"
+            to use for the Trivy parser script, defaults to "4.5.7"
         trivy_version (str): Version of Trivy to install, defaults to "0.65.0"
 
     Functionality:

--- a/cdk_opinionated_constructs/stages/logic/__init__.py
+++ b/cdk_opinionated_constructs/stages/logic/__init__.py
@@ -627,7 +627,7 @@ def scan_image_with_trivy(
     cpu_architecture: Literal["arm64", "amd64"],
     pipeline_artifacts_bucket: s3.Bucket | s3.IBucket,
     trivy_version: str = "0.65.0",
-    cdk_opinionated_constructs_version: str = "4.5.4",
+    cdk_opinionated_constructs_version: str = "4.5.7",
 ) -> pipelines.CodeBuildStep:
     """
     Parameters:
@@ -637,7 +637,7 @@ def scan_image_with_trivy(
         cpu_architecture (Literal["arm64", "amd64"]): CPU architecture for the build environment
         pipeline_artifacts_bucket (s3.Bucket | s3.IBucket): S3 bucket for storing build artifacts
         trivy_version (str): Version of Trivy scanner to install (defaults to "0.65.0")
-        cdk_opinionated_constructs_version (str): Version of CDK constructs package (defaults to "4.5.4")
+        cdk_opinionated_constructs_version (str): Version of CDK constructs package (defaults to "4.5.7")
 
     Functionality:
         Creates a CodeBuild step that performs security scanning of container images using Trivy:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="4.5.7",
+    version="4.5.8",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION
Updated `cdk_opinionated_constructs_version` to `4.5.7` across relevant modules and incremented the project version to `4.5.8` in `setup.py`.

These changes ensure the project remains consistent with the latest library updates, maintaining compatibility with improvements and fixes introduced in the updated dependency version.