### PR TITLE
chore(deps): update dependencies and increment project version to 4.5.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: ssort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.12.7'
+    rev: 'v0.12.8'
     hooks:
       - id: ruff
         args: [ --fix]

--- a/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
+++ b/cdk_opinionated_constructs/libs/pipeline_v2/trivy_scaner.py
@@ -54,7 +54,11 @@ def _create_trivy_install_commands(
     """
 
     _install_commands = [
-        "pip3 install boto3 click",
+        "n 22",
+        "pip install uv",
+        "make venv",
+        "source .venv/bin/activate",
+        "pip install boto3 click cdk-opinionated-constructs",
         "curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin",
     ]
 

--- a/cdk_opinionated_constructs/stages/logic/__init__.py
+++ b/cdk_opinionated_constructs/stages/logic/__init__.py
@@ -660,7 +660,11 @@ def scan_image_with_trivy(
     )
 
     _install_commands = [
-        "pip3 install boto3 click",
+        "n 22",
+        "pip install uv",
+        "make venv",
+        "source .venv/bin/activate",
+        "pip install boto3 click cdk-opinionated-constructs",
     ]
 
     if cpu_architecture == "amd64":

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdk-opinionated-constructs",
-    version="4.5.9",
+    version="4.5.10",
     description="AWS CDK constructs come without added security configurations.",
     long_description="The idea behind this project is to create secured constructs from the start. \n"
     "Supported constructs: ALB, ECR, LMB, NLB, S3, SNS, WAF, RDS",


### PR DESCRIPTION
Updated `cdk-opinionated-constructs` to version `4.5.10` in `setup.py` and bumped the project version accordingly. Improved Trivy scanner initialization by refining installation commands to include virtual environment setup and updated `.pre-commit-config.yaml` to use `ruff` version `v0.12.8`.

These changes enhance dependency consistency, streamline development workflows, and maintain compatibility with the latest updates.